### PR TITLE
add quotes to variable

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -1304,7 +1304,7 @@ set_portage() {
 
 	set_use_mask ${pkg} "${mask}"
 	set_use_force ${pkg} "${force}"
-	set_keywords ${pkg} ${ver}
+	set_keywords ${pkg} "${ver}"
 	set_use ${pkg} ${use}
 	set_links ${cat} ${pkg} "${ovl}"
 	set_env ${l} ${pkg} "${env}"


### PR DESCRIPTION
I'm running Gentoo on two machines. One compiles packages and hosts a binhost for the other. Yet, for some reason, crossdev has some very peculiar behaviour on the non-binhost, which should have the exact same binaries as the binhost machine.
Crossdev works as expected for e.g `crossdev -t x86_64-pc-linux-musl` on the binhost. It generates a `/etc/portage/package.accept_keywords/cross-x86_64-pc-linux-musl` file like this:
```
cross-x86_64-pc-linux-musl/binutils amd64 ~amd64
cross-x86_64-pc-linux-musl/gcc amd64 ~amd64
cross-x86_64-pc-linux-musl/linux-headers amd64 ~amd64
cross-x86_64-pc-linux-musl/musl amd64 ~amd64
cross-x86_64-pc-linux-musl/gdb amd64 ~amd64
```
However, on the other machine, it generates a bogus one like this:
```
cross-x86_64-pc-linux-musl/binutils -*
across-x86_64-pc-linux-musl/binutils- * ~* **
cross-x86_64-pc-linux-musl/gcc -*
across-x86_64-pc-linux-musl/gcc- * ~* **
cross-x86_64-pc-linux-musl/linux-headers -*
across-x86_64-pc-linux-musl/linux-headers- * ~* **
cross-x86_64-pc-linux-musl/musl -*
across-x86_64-pc-linux-musl/musl- * ~* **
cross-x86_64-pc-linux-musl/gdb amd64 ~amd64
```

I managed to trace it back to the variable `$ver` in `set_portage`. Some echo-based debugging™ reveals that `$ver` evaluates to `a`, while `"$ver"` evaluates to `[latest]`. Accessing it via `$*` had similar results, with the category and package name being preserved, but the version being just `a`, for example, with `sys-devel binutils a`.

I couldn't manage to create a minimal working example of this outside of crossdev (with all of the funky stuff with e.g function calls, `set -- \"\${${a}bc}\"`, `shift` and so on), and I'm not sure what's causing it. The machines' binaries and crossdev scripts are synced, hash-for-hash. The only thing I could determine was that quoting this variable would fix this for me.