### PR TITLE
wrappers: Actually set PKGDIR to /var/cache/binpkgs

### DIFF
--- a/wrappers/etc/portage/make.conf
+++ b/wrappers/etc/portage/make.conf
@@ -16,7 +16,7 @@ CXXFLAGS="${CFLAGS}"
 
 FEATURES="-collision-protect sandbox buildpkg noman noinfo nodoc"
 # Be sure we dont overwrite pkgs from another repo..
-PKGDIR=${ROOT}cache/binpkgs/
+PKGDIR=${ROOT}var/cache/binpkgs/
 PORTAGE_TMPDIR=${ROOT}tmp/
 
 PKG_CONFIG_PATH="${ROOT}usr/lib/pkgconfig/"


### PR DESCRIPTION
Probably a typo, so accidentally got changed to `/cache/binpkgs` instead of `/var/cache/binpkgs`

Signed-off-by: Jakov Smolić <jsmolic@gentoo.org>