### PR TITLE
Call emerge instead of qmerge to unmerge packages

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -638,7 +638,7 @@ uninstall() {
 	rmdir "${EPREFIX}"/etc/revdep-rebuild 2>/dev/null
 
 	# Unmerge all toolchain packages for this target.
-	qmerge -Uqy $(qlist -IC "cross-${CTARGET}/")
+	emerge -q --rage-clean "cross-${CTARGET}/*"
 
 	# clean out known toolchain files (binutils/gcc)
 	for f in \

--- a/crossdev
+++ b/crossdev
@@ -584,9 +584,6 @@ uninstall() {
 	ewarn "Uninstalling target '${CTARGET}' ..."
 
 	# clean out portage config files
-	if grep -qs "^cross-${CTARGET}/" "${EPREFIX}"/var/lib/portage/world ; then
-		sed -i "/^cross-${CTARGET}/d" "${EPREFIX}"/var/lib/portage/world
-	fi
 	if [[ -d ${CROSSDEV_OVERLAY}/cross-${CTARGET} ]]; then
 		rm -r "${CROSSDEV_OVERLAY}"/cross-${CTARGET}
 		# if we remove all the package in the category,


### PR DESCRIPTION
qmerge does not remove packages from the world file. Also, this allows us to drop the dependency on portage-utils.