### PR TITLE
Fix wrong ABI detection for MIPS64 Musl toolchains

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -310,6 +310,8 @@ parse_target() {
 		mips64*-gnuabi32|mipsisa64*-gnuabi32|\
 		mips64*-gnuabio32|mipsisa64*-gnuabio32)
 		      [[ ${MULTILIB_ABIS} == "default" ]] && MULTILIB_ABIS="o32";;
+		mips64*-musl)
+		      [[ ${MULTILIB_ABIS} == "default" ]] && MULTILIB_ABIS="n64";;
 	esac
 
 	# Tweak packages based upon CTARGET


### PR DESCRIPTION
Currently the tuple mips64*-musl sets a n32 abi which isn't supported by Musl and causes numerous issues, so this simple fix will force a n64 abi.

Signed-off-by: Ian Jordan <immoloism@gmail.com>