### PR TITLE
Avoid calling portageq from Makefile

### DIFF
--- a/wrappers/Makefile
+++ b/wrappers/Makefile
@@ -1,9 +1,8 @@
-# Copyright 2008-2010 Gentoo Foundation
+# Copyright 2008-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 include ../settings.mk
 
-PORTDIR ?= $(shell portageq envvar PORTDIR)
 FNAMES = cross-ebuild cross-emerge cross-fix-root cross-pkg-config emerge-wrapper
 SITEDIR = $(PREFIX)/share/crossdev/include/site
 ETC_SITEDIR = $(EPREFIX)/etc/crossdev/include/site
@@ -24,6 +23,5 @@ install:
 	sed -i -e s:@SITEDIR@:$(SITEDIR):g $(DESTDIR)$(SITEDIR)/config.site
 	sed -i -e s:@ETC_SITEDIR@:$(ETC_SITEDIR):g $(DESTDIR)$(SITEDIR)/config.site
 	mv $(DESTDIR)$(SITEDIR)/config.site $(DESTDIR)$(PREFIX)/share/
-	ln -sf $(PORTDIR)/profiles/embedded $(DESTDIR)$(PREFIX)/share/crossdev/etc/portage/make.profile
 
 .PHONY: all install

--- a/wrappers/emerge-wrapper
+++ b/wrappers/emerge-wrapper
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright 2008-2010 Gentoo Foundation
+# Copyright 2008-2023 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 if [[ $1 == "--help" || $1 == "-h" ]] ; then
@@ -37,6 +37,7 @@ cross_wrap_etc()
 	setup_warning=false
 
 	cp -a "${PREFIX}"/share/crossdev/etc ${SYSROOT}/     || return 1
+	ln -snf "${MAIN_REPO_PATH}/profiles/embedded" "${SYSROOT}/etc/portage/make.profile" || return 1
 
 	local confs=(
 		${SYSROOT}/etc/portage/make.conf


### PR DESCRIPTION
It is probably better to look up the repo path at runtime anyway.

Bug: https://bugs.gentoo.org/908602