### PR TITLE
cross-pkg-config: Properly set PKG_CONFIG_SYSTEM_*_PATH variables

### DIFF
--- a/wrappers/cross-pkg-config
+++ b/wrappers/cross-pkg-config
@@ -118,7 +118,9 @@ if [ -z "${libdir}" ] ; then
 	libdir=${libdir##*/}
 fi
 : ${libdir:=lib}
-export PKG_CONFIG_SYSTEM_LIBRARY_PATH="${PREFIX}/usr/${libdir}:${PREFIX}/${libdir}"
+export \
+	PKG_CONFIG_SYSTEM_LIBRARY_PATH="${PKG_CONFIG_ESYSROOT_DIR}/usr/${libdir}:${PKG_CONFIG_ESYSROOT_DIR}/${libdir}" \
+	PKG_CONFIG_SYSTEM_INCLUDE_PATH="${PKG_CONFIG_ESYSROOT_DIR}/usr/include"
 
 #
 # Set the pkg-config search paths to our staging directory.


### PR DESCRIPTION
Perhaps this was a difference between pkg-config and pkgconf, but we have not set `PKG_CONFIG_SYSTEM_LIBRARY_PATH` correctly since we began setting it in 2014. It should include the `SYSROOT`. We also never set `PKG_CONFIG_SYSTEM_INCLUDE_PATH` at all.

These variables tell pkg-config not to emit paths that the toolchain would search in anyway. This helps to reduce the noise appearing in newly-installed .pc files.

This change does assume that if you have set `SYSROOT` differently to the toolchain's default, then you have also added the `--sysroot` argument to your compiler flags. Neither Portage nor Gentoo currently do this for you. cross-boss does, but it's not an officially supported solution. The change could therefore potentially break things, but it's likely you'll run into other problems if you don't add `--sysroot` anyway.