### PR TITLE
Fix check for installed LLVM

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -1722,7 +1722,7 @@ if ! ex_fast ; then
 
 	# stage 0: binutils
 	if [[ "${LLVM}" == "yes" ]] ; then
-		if [[ $(portageq has_version / "sys-devel/llvm") -ne 0 ]] ; then
+		if ! portageq has_version / "sys-devel/llvm" ; then
 			eerror "LLVM is not installed"
 			exit 1
 		fi


### PR DESCRIPTION
It always succeeds, and then if LLVM isn't installed, crossdev fails with a confusing error:

    Target architecture not supported by installed LLVM toolchain