### PR TITLE
cross-pkg-config: Set PKG_CONFIG_FDO_SYSROOT_RULES=1

### DIFF
--- a/wrappers/cross-pkg-config
+++ b/wrappers/cross-pkg-config
@@ -95,6 +95,9 @@ fi
 export PKG_CONFIG_SYSROOT_DIR=${PKG_CONFIG_SYSROOT_DIR%/}
 PKG_CONFIG_ESYSROOT_DIR=${PKG_CONFIG_SYSROOT_DIR}${PREFIX}
 
+# https://github.com/pkgconf/pkgconf/issues/205
+export PKG_CONFIG_FDO_SYSROOT_RULES=1
+
 #
 # Some distributions pollute the pkg-config environment.
 # Time to pull a captain planet on them.


### PR DESCRIPTION
When cross-compiling, pkgconf behaves in a way that causes many packages to install files to ${SYSROOT}/${SYSROOT}/... without PKG_CONFIG_FDO_SYSROOT_RULES set.

I'm aware of at least gobject-introspection, modemmanager, and libp11, but there are likely more.