### PR TITLE
wrapper/etc/portage/make.conf: Remove -pam

### DIFF
--- a/wrappers/etc/portage/make.conf
+++ b/wrappers/etc/portage/make.conf
@@ -9,7 +9,7 @@ ROOT=@GENTOO_PORTAGE_EPREFIX@/usr/${CHOST}/
 
 ACCEPT_KEYWORDS="${ARCH} ~${ARCH}"
 
-USE="${ARCH} -pam"
+USE="${ARCH}"
 
 CFLAGS="-O2 -pipe -fomit-frame-pointer"
 CXXFLAGS="${CFLAGS}"


### PR DESCRIPTION
Removing default option of disabling PAM as no longer needed in all tests done.