### PR TITLE
crossdev: Force static-libs for -gnu targets

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -354,6 +354,9 @@ parse_target() {
 			;;
 		*-gnu*)
 			LPKG="glibc"
+			# gcc would not find -lpthread without static libraries while building
+			# its copy of libgomp.
+			LUSE+=" static-libs"
 			;;
 		*-klibc)
 			LPKG="klibc"


### PR DESCRIPTION
Tested issuing `crossdev riscv64` when the host has `USE=-static-libs`, w/out the patch it fails while with this patch it completes without problems.