### PR TITLE
crossdev: Use libunwind and libc++ in LLVM environments

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -1736,7 +1736,8 @@ if [[ "${LLVM}" == "yes" ]]; then
 	--rtlib=compiler-rt
 	--sysroot=/usr/${CTARGET}
 	--target=${CTARGET}
-	--unwindlib=none
+	--unwindlib=libunwind
+	--stdlib=libc++
 	-fuse-ld=lld
 	EOF
 	# Workaround until LLVM libc supports dynamic linking and SSP


### PR DESCRIPTION
Avoid build issues on cross environments using musl and LLVM by using libunwind and libc++ explicitly in the clang configuration. Otherwise, clang expects GCC libunwind and libstdc++.

These flags were not set explicitly in the clang configuration, because LLVM profiles were setting them, but that's not the case anymore[0].

[0] https://github.com/gentoo/gentoo/commit/5e5c9d5c524871f5af260557dbd2962b8eec5087

Bug: https://bugs.gentoo.org/941140