### PR TITLE
ci: Run the container explicitly with `docker run`

### DIFF
--- a/.github/workflows/crossdev.yml
+++ b/.github/workflows/crossdev.yml
@@ -22,26 +22,27 @@ jobs:
           - musl
     name: crossdev target=${{ matrix.target }} stage3=${{ matrix.stage3 }}
     runs-on: ubuntu-latest
-    container: docker.io/gentoo/stage3:${{ matrix.stage3 }}
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install dependencies
-        run: |
-          emerge --sync --quiet
-          emerge \
-            app-eselect/eselect-repository \
-            sys-apps/config-site
-
-      - name: Install crossdev
-        run: make install
-
       - name: Create cross environment
         run: |
-          eselect repository create crossdev
-          crossdev ${{ matrix.args }} --target ${{ matrix.target }}
+          docker run -v $(pwd):/workspace -w /workspace \
+            docker.io/gentoo/stage3:${{ matrix.stage3 }} bash -c "
+            # Install dependencies
+            emerge --sync --quiet
+            emerge \
+              app-eselect/eselect-repository \
+              sys-apps/config-site
 
-      # zstd and its dependencies need both C and C++ toolchain. If any of them
-      # is broken, the installation will fail.
-      - name: Sanity check
-        run: ${{ matrix.target }}-emerge app-arch/zstd
+            # Install crossdev
+            make install
+
+            # Create cross environment
+            eselect repository create crossdev
+            crossdev ${{ matrix.args }} --target ${{ matrix.target }}
+
+            # zstd and its dependencies need both C and C++ toolchain. If any of them
+            # is broken, the installation will fail.
+            run: ${{ matrix.target }}-emerge app-arch/zstd
+            "


### PR DESCRIPTION
Using `container:` setting in GitHub actions unfortunately doesn't work with musl-llvm Gentoo images. The reason is that GitHub actions are injecting a NodeJS binary and for distros other than Alpine, it injects a binary linked against glibc.[0]

The proper fix would involve either defaulting to musl or making the libc detection in the container system smarter, but for now, let's just run the container manually.

[0] https://github.com/actions/runner/blob/6ef5803f24724b77a8d3599a478d06018da5d7c6/src/Runner.Worker/Handlers/StepHost.cs#L143-L172