### PR TITLE
ci: Test more targets, move the testing logic to a script

### DIFF
--- a/.github/workflows/crossdev.yml
+++ b/.github/workflows/crossdev.yml
@@ -14,35 +14,88 @@ jobs:
   crossdev:
     strategy:
       matrix:
+        # All targets which are known to be broken, are commented. Pull
+        # requests fixing them welcome!
         target:
-          - aarch64-unknown-linux-gnu
-          - aarch64-unknown-linux-musl
+          - target: aarch64-unknown-linux-gnu
+          - target: aarch64-unknown-linux-musl
+          - target: arm-unknown-linux-gnueabi
+          - target: arm-unknown-linux-gnueabihf
+          - target: arm-unknown-linux-musleabi
+          - target: arm-unknown-linux-musleabihf
+          - target: armeb-unknown-linux-gnueabi
+          - target: armeb-unknown-linux-gnueabihf
+          - target: armeb-unknown-linux-musleabi
+          - target: armeb-unknown-linux-musleabihf
+          # glibc fails to build: `attempt to use an ARM instruction on a
+          # Thumb-only processor`.
+          # - target: armv7-unknown-linux-gnueabi
+          # - target: armv7-unknown-linux-gnueabihf
+          - target: armv7-unknown-linux-musleabi
+          - target: armv7-unknown-linux-musleabihf
+          # binutils fails to configure: `machine 'loongaarch64-unknown' not
+          # recognized`
+          # - target: loongaarch64-unknown-linux-gnu
+          # - target: loongaarch64-unknown-linux-musl
+          - target: m68k-unknown-linux-gnu
+          - target: mips-unknown-linux-gnu
+          - target: mips-unknown-linux-musl
+          - target: mipsel-unknown-linux-gnu
+          - target: mipsel-unknown-linux-musl
+          - target: mips64-unknown-linux-gnu
+          # libgcc_s.so fails to build: `cannot find crti.o: No such file or
+          # directory`.
+          # - target: mips64-unknown-linux-musl
+          - target: mips64el-unknown-linux-gnu
+          # libgcc_s.so fails to build: `cannot find crti.o: No such file or
+          # directory`.
+          # - target: mips64el-unknown-linux-musl
+          - target: or1k-unknown-linux-gnu
+            args: --skip-system
+          - target: or1k-unknown-linux-musl
+            args: --skip-system
+          - target: powerpc-unknown-linux-gnu
+          - target: powerpc-unknown-linux-musl
+          - target: powerpc64-unknown-linux-gnu
+          - target: powerpc64-unknown-linux-musl
+          - target: riscv32-unknown-linux-gnu
+          # busybox fails to buils: `‘SYS_settimeofday’ undeclared`.
+          # - target: riscv32-unknown-linux-musl
+          - target: riscv64-unknown-linux-gnu
+          - target: riscv64-unknown-linux-musl
+          # glibc fails to build: `no support for pre-v8 sparc`.
+          # - target: sparc-unknown-linux-gnu
+          - target: sparc64-unknown-linux-gnu
+          - target: s390x-unknown-linux-gnu
+          # musl ebuilds don't support s390x. The target is supported upstream,
+          # we need to fix and test our ebuilds.
+          # - target: s390x-unknown-linux-musl
+          # All sh* targets fail to install binutils, because of a missing
+          # keyword.
+          # - target: sh2-unknown-linux-gnu
+          # - target: sh2-unknown-linux-musl
+          # - target: sh2eb-unknown-linux-gnu
+          # - target: sh2eb-unknown-linux-musl
+          # - target: sh4-unknown-linux-gnu
+          # - target: sh4-unknown-linux-musl
+          # - target: sh4eb-unknown-linux-gnu
+          # - target: sh4eb-unknown-linux-musl
+          - target: x86_64-unknown-linux-gnu
+          - target: x86_64-unknown-linux-musl
         stage3:
           - latest # `openrc` (glibc+GCC) is tagged as `latest`
-          - musl
-    name: crossdev target=${{ matrix.target }} stage3=${{ matrix.stage3 }}
+          - musl 
+      fail-fast: false
+    name: crossdev target=${{ matrix.target.target }} stage3=${{ matrix.stage3 }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: Create cross environment
+        env:
+          CONTAINER_ENGINE: docker
         run: |
-          docker run -v $(pwd):/workspace -w /workspace \
-            docker.io/gentoo/stage3:${{ matrix.stage3 }} bash -c "
-            # Install dependencies
-            emerge --sync --quiet
-            emerge \
-              app-eselect/eselect-repository \
-              sys-apps/config-site
-
-            # Install crossdev
-            make install
-
-            # Create cross environment
-            eselect repository create crossdev
-            crossdev ${{ matrix.args }} --target ${{ matrix.target }}
-
-            # zstd and its dependencies need both C and C++ toolchain. If any of them
-            # is broken, the installation will fail.
-            run: ${{ matrix.target }}-emerge app-arch/zstd
-            "
+          ./scripts/container_test.sh \
+            --tag ${{ matrix.stage3 }} \
+            --target ${{ matrix.target.target }} \
+            ${{ matrix.target.args }}

--- a/README
+++ b/README
@@ -293,3 +293,18 @@ Various notes (AKA dirty little tricks)
   additional --test options).
 
 Happy cross-compiling!
+
+Testing
+-------
+
+This repository provides a script for testing crossdev in a container. It can
+be used to verify whether crossdev works for various host profiles:
+
+  $ ./scripts/container_test.sh --target aarch64-unknown-linux-musl
+  $ ./scripts/container_test.sh --tag musl --target aarch64-unknown-linux-musl
+
+--tag determines the container tag of the docker.io/gentoo/stage3 image used in
+the script and can be used to pick the appropriate host stage3/profile to use.
+
+This script is used by the CI job to test the whole matrix of supported host
+profiles and targets.

--- a/scripts/container_test.sh
+++ b/scripts/container_test.sh
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+set -e
+
+print_help() {
+	echo "Usage: $0 [OPTIONS]
+
+Options:
+  --skip-system         Skip emerging the @system set after setting up crossdev.
+  --tag <tag>           Specify the container tag to use. Default is 'latest'.
+  --target <target>     Specify the target architecture for crossdev. Required.
+  -h, --help            Show this help message and exit.
+
+Environment Variables:
+  CONTAINER_ENGINE      Specify the container engine to use (docker or podman).
+                        Default is detected automatically.
+  CONTAINER_NAME        Name of the container instance. Default is 'crossdev'.
+  CONTAINER_URI         URI of the container image. Default is 'docker.io/gentoo/stage3'.
+
+Examples:
+  # Run with the default container and target architecture
+  $0 --target aarch64-unknown-linux-gnu
+
+  # Run with a specific container tag and skip emerging @system
+  $0 --tag stable --target riscv64-unknown-linux-musl --skip-system
+
+Notes:
+  - You must specify a target using the --target option.
+  - Ensure the container engine (docker or podman) is installed and available."
+}
+
+detect_container_engine() {
+	if command -v podman &>/dev/null; then
+		echo "podman"
+	elif command -v docker &>/dev/null; then
+		echo "docker"
+	else
+		echo "No container engine found. The supported ones are: docker, podman."
+		exit 1
+	fi
+}
+
+remove_container() {
+	"${CONTAINER_ENGINE}" rm -f "${CONTAINER_NAME}" "$@"
+}
+
+run_in_container() {
+	echo "+ $@"
+	"${CONTAINER_ENGINE}" exec "${CONTAINER_NAME}" "$@"
+}
+
+CONTAINER_ENGINE=${CONTAINER_ENGINE:-$(detect_container_engine)}
+CONTAINER_NAME=${CONTAINER_NAME:-"crossdev"}
+CONTAINER_URI=${CONTAINER_URI:-"docker.io/gentoo/stage3"}
+CONTAINER_TAG="latest"
+EMERGE_SYSTEM=1
+TOPDIR=$(git rev-parse --show-toplevel)
+
+remove_container || true
+trap "remove_container" EXIT
+
+while [[ $# -gt 0 ]]; do
+	case $1 in
+		-h|--help)
+			print_help
+			exit 0
+			;;
+		--skip-system)
+			EMERGE_SYSTEM=0
+			shift 1
+			;;
+		--tag)
+			CONTAINER_TAG="$2"
+			shift 2
+			;;
+		--target)
+			TARGET="$2"
+			shift 2
+			;;
+		*)
+			echo "Unknown option: $1"
+			print_help
+			exit 1
+			;;
+	esac
+done
+
+"${CONTAINER_ENGINE}" run -d \
+	--name "${CONTAINER_NAME}" \
+	-v "${TOPDIR}:/workspace" \
+	-w /workspace \
+	"${CONTAINER_URI}:${CONTAINER_TAG}" \
+	/bin/sleep inf
+
+run_in_container emerge-webrsync
+run_in_container emerge app-eselect/eselect-repository sys-apps/config-site
+run_in_container make install
+run_in_container eselect repository create crossdev
+run_in_container crossdev --show-fail-log --target "${TARGET}"
+if [[ "${EMERGE_SYSTEM}" -eq 1 ]]; then
+	run_in_container "${TARGET}-emerge" @system
+fi


### PR DESCRIPTION
Cover all possible targets. The ones which fail to build, are disabled with an appropriate comment explaining the error.

To make the tests easier to reproduce locally, provide the `container_test.sh` script and move the most of logic there.