### PR TITLE
crossdev: allow --ex-pkg to install stable

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -1023,6 +1023,10 @@ case ${ACTION} in
 uninstall) uninstall; exit 0;;
 esac
 
+for _ in "${XPKGS[@]}"; do
+	XVERS+=( "${DEFAULT_VER}" )
+done
+
 BVER=${BVER:-${DEFAULT_VER}}
 GVER=${GVER:-${DEFAULT_VER}}
 KVER=${KVER:-${DEFAULT_VER}}


### PR DESCRIPTION
At present, --ex-pkg flags always install the [latest] version. However, sometimes one may want to install [stable] if required.