### PR TITLE
Blank out KERNEL on unknown kernel

### DIFF
--- a/wrappers/emerge-wrapper
+++ b/wrappers/emerge-wrapper
@@ -66,7 +66,7 @@ cross_wrap_etc()
 	*)        emit_setup_warning "No LIBC is known for this target." ;;
 	esac
 
-	KERNEL="__KERNEL__"
+	KERNEL=""
 	case ${CHOST} in
 	*linux*)  KERNEL=linux ;;
 	*mingw*)  KERNEL=Winnt ;;

--- a/wrappers/etc/portage/profile/make.defaults
+++ b/wrappers/etc/portage/profile/make.defaults
@@ -1,3 +1,3 @@
 ARCH="__ARCH__"
-KERNEL="-linux __KERNEL__"
+KERNEL="__KERNEL__"
 ELIBC="__LIBC__"


### PR DESCRIPTION
Was running into an issue in make.defaults where it was parsing out to '-linux __KERNEL__' Which is very wrong. Doing things slightly better

Suggested-by: sam