### PR TITLE
wrappers: linux-{gnu,musl}: set gl_cv_func_strcasecmp_works for gnulib

### DIFF
--- a/wrappers/site/linux-gnu
+++ b/wrappers/site/linux-gnu
@@ -86,3 +86,7 @@ screen_cv_sys_select_broken_retval=${screen_cv_sys_select_broken_retval=no}
 screen_cv_sys_sockets_nofs=${screen_cv_sys_sockets_nofs=no}
 screen_cv_sys_sockets_usable=${screen_cv_sys_sockets_usable=yes}
 screen_cv_sys_terminfo_used=${screen_cv_sys_terminfo_used=yes}
+
+# gnulib (nano et al.)
+# https://bugs.gentoo.org/953104
+gl_cv_func_strcasecmp_works=yes

--- a/wrappers/site/linux-musl
+++ b/wrappers/site/linux-musl
@@ -2,3 +2,7 @@
 # bug #705800 and many others
 ac_cv_func_malloc_0_nonnull=yes
 ac_cv_func_realloc_0_nonnull=yes
+
+# gnulib (nano et al.)
+# https://bugs.gentoo.org/953104
+gl_cv_func_strcasecmp_works=yes


### PR DESCRIPTION
Recent gnulib added a check for strcasecmp which the build system tries to execute when cross-compiling, so we can set the corresponding variable to avoid running in until its fixed upstream.

Closes: https://bugs.gentoo.org/953104