### PR TITLE
cross-pkg-config: remember PKG_CONFIG from build time

### DIFF
--- a/wrappers/Makefile
+++ b/wrappers/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2008-2023 Gentoo Authors
+# Copyright 2008-2025 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 include ../settings.mk
@@ -6,6 +6,7 @@ include ../settings.mk
 FNAMES = cross-ebuild cross-emerge cross-fix-root cross-pkg-config emerge-wrapper
 SITEDIR = $(PREFIX)/share/crossdev/include/site
 ETC_SITEDIR = $(EPREFIX)/etc/crossdev/include/site
+PKG_CONFIG ?= pkg-config
 
 all:
 
@@ -15,6 +16,7 @@ install:
 	sed -i -e s:@PREFIX@:$(PREFIX):g $(DESTDIR)$(ETC_SITEDIR)/README
 	$(INSTALL_EXEC) $(FNAMES) $(DESTDIR)$(PREFIX)/bin/
 	sed -i -e "s:@GENTOO_PORTAGE_EPREFIX@:$(EPREFIX):g" $(DESTDIR)$(PREFIX)/bin/cross-emerge
+	sed -i -e "s:@PKG_CONFIG@:$(PKG_CONFIG):g" $(DESTDIR)$(PREFIX)/bin/cross-pkg-config
 	sed -i -e "s:@GENTOO_PORTAGE_EPREFIX@:$(EPREFIX):g" $(DESTDIR)$(PREFIX)/bin/emerge-wrapper
 	cp -a etc $(DESTDIR)$(PREFIX)/share/crossdev/
 	sed -i -e "s:@GENTOO_PORTAGE_EPREFIX@:$(EPREFIX):g" $(DESTDIR)$(PREFIX)/share/crossdev/etc/portage/make.conf

--- a/wrappers/cross-pkg-config
+++ b/wrappers/cross-pkg-config
@@ -20,7 +20,9 @@ error() {
 	exit 1
 }
 
-REAL_PKG_CONFIG="${CBUILD}${CBUILD:+-}pkg-config"
+if [ -z "${REAL_PKG_CONFIG}" ]; then
+	REAL_PKG_CONFIG="@PKG_CONFIG@"
+fi
 if ! command -v "${REAL_PKG_CONFIG}" >/dev/null; then
 	REAL_PKG_CONFIG=pkg-config
 fi


### PR DESCRIPTION
This should avoid recursive cross-pkg-config calls when someone sets CBUILD = CHOST in the cross-emerge environment, which might be useful for building a system image with SYSROOT != /.

For sys-devel/crossdev we will call "tc-export PKG_CONFIG" to set a reasonable default for REAL_PKG_CONFIG. This will generally be ${CHOST}-pkg-config, where CBUILD = CHOST and SYSROOT = ROOT = /.

In the case we are cross-compiling crossdev itself, we want ${CHOST}-pkg-config for REAL_PKG_CONFIG in SYSROOT/ROOT in case it is later used as a root image on appropriate hardware.

We also allow the user to override REAL_PKG_CONFIG via the environment in case some unforseen use case is discovered.

Bug: https://bugs.gentoo.org/955822