### PR TITLE
sys-devel/crossdev forces multilib for arm toolchains

### DIFF
--- a/.github/workflows/crossdev.yml
+++ b/.github/workflows/crossdev.yml
@@ -189,6 +189,218 @@ jobs:
             args: --skip-system
             gcc: true
             llvm: false
+          # Cortex-M / ARMv6-M through ARMv8.1-M non-multilib targets
+          - target: armv6m-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6sm-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7em-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7em-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7em-softfp-none-eabi
+            args: --skip-system --env 'EXTRA_ECONF="--with-fpu=fpv4-sp-d16"'
+            gcc: true
+            llvm: false
+          - target: armv7em-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7em-none-eabihf
+            args: --skip-system --env 'EXTRA_ECONF="--with-fpu=fpv4-sp-d16"'
+            gcc: true
+            llvm: false
+          - target: armv7m-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8m.base-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8m.main-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8m.main-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8m.main-softfp-none-eabi
+            args: --skip-system --env 'EXTRA_ECONF="--with-fpu=fpv5-sp-d16"'
+            gcc: true
+            llvm: false
+          - target: armv8m.main-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8m.main-none-eabihf
+            args: --skip-system --env 'EXTRA_ECONF="--with-fpu=fpv5-sp-d16"'
+            gcc: true
+            llvm: false
+          - target: armv8.1m.main+mve-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8.1m.main+pacbti-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8.1m.main+pacbti+fp-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8.1m.main+pacbti+fp-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8.1m.main+pacbti+fp.dp-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8.1m.main+pacbti+fp.dp-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8.1m.main+pacbti+mve-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          # Cortex-A / ARMv7-A, ARMv7-R, ARMv8-A non-multilib targets
+          - target: armv7a-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7a-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7a-softfp-none-eabi
+            args: --skip-system --env 'EXTRA_ECONF="--with-fpu=neon-vfpv3"'
+            gcc: true
+            llvm: false
+          - target: armv7a-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7a-none-eabihf
+            args: --skip-system --env 'EXTRA_ECONF="--with-fpu=neon-vfpv3"'
+            gcc: true
+            llvm: false
+          - target: armv7r-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7r-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7r-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7ve-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7ve-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7ve-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8a-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8a-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv8a-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          # Generic ARMv4 through ARMv7 non-multilib targets
+          - target: arm-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv4-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv4t-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv5t-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv5te-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv5te-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv5te-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6j-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6t2-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6t2-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv6t2-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7-softfloat-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7-softfp-none-eabi
+            args: --skip-system
+            gcc: true
+            llvm: false
+          - target: armv7-none-eabihf
+            args: --skip-system
+            gcc: true
+            llvm: false
+          # Embedded or otherwise special targets
           - target: avr
             args: --skip-system
             gcc: true

--- a/crossdev
+++ b/crossdev
@@ -273,7 +273,7 @@ parse_target() {
 			KPKG="[none]"
 			LCAT="dev-embedded" LPKG="avr-libc"
 			GUSE+=" -openmp -fortran -go" # doesn't work
-			MULTILIB_USE="yes" #377039
+			MULTILIB_USE="yes" # avr requires multilib, that provides libgcc for all sub-architectures #378387, #377039
 			BUSE+=" cxx"
 			WITH_DEF_HEADERS="no"
 			;;
@@ -342,7 +342,8 @@ parse_target() {
 			# for that.
 			GUSE+=" zlib zstd"
 
-			# We need multilib for openmp to be built w/ -mgomp
+			# We need multilib for openmp to be built w/ -mgomp 
+			# https://gcc.gnu.org/legacy-ml/gcc-help/2020-01/msg00106.html
 			MULTILIB_USE="yes"
 			WITH_DEF_HEADERS="no"
 			;;
@@ -367,6 +368,7 @@ parse_target() {
 			GUSE+=" zlib zstd"
 
 			# We need multilib for openmp to be built w/ -mgomp
+			# https://gcc.gnu.org/legacy-ml/gcc-help/2020-01/msg00106.html
 			MULTILIB_USE="yes"
 			WITH_DEF_HEADERS="no"
 			;;
@@ -446,7 +448,7 @@ parse_target() {
 			;;
 
 		# Bare metal targets
-		*-newlib|*-elf|*-eabi|*-rtems*)
+		*-newlib|*-elf|*-eabi|*-eabihf|*-rtems*)
 			LPKG="newlib"
 			KPKG="[none]"
 			GMASK+=" default-stack-clash-protection hardened ssp"
@@ -454,7 +456,9 @@ parse_target() {
 			GUSE+=" -fortran" #589672, needs syscalls
 			GUSE+=" -hardened" #687598, needs -fstack-check=specific support
 			GUSE+=" -default-stack-clash-protection -ssp" # SSP isn't supported for freestanding anyway
-			MULTILIB_USE="yes" #407275
+
+			[[ "$CTARGET" != armv*-eabi* && "$CTARGET" != arm-soft*-* ]] \
+				&& MULTILIB_USE="yes" #868636, #407275
 			WITH_DEF_HEADERS="no"
 			;;
 
@@ -546,7 +550,7 @@ parse_target() {
 		mingw*|*-mingw*) pie_support=no
 			;;
 		# Many bare-metal targets don't work with pie as-is
-		*-elf|*-eabi)
+		*-elf|*-eabi|*-eabihf)
 			# mips can't generate freestanding PIC:
 			#   cc1: error: position-independent code requires ‘-mabicalls’
 			# arm firmware packages don't expect pie-by-default:
@@ -1528,27 +1532,12 @@ set_portage() {
 
 	[[ ${pkg} == "[none]" ]] && return 0
 
-	case ${CTARGET} in
-		# avr requires multilib, that provides
-		# libgcc for all sub-architectures #378387
-		avr*)
-			mask+=" -multilib"
-			force+=" multilib"
-			;;
-		accel-nvptx*|nvptx*|*-newlib|*-elf|*-eabi)
-			# nvptx: needs multilib because of https://gcc.gnu.org/legacy-ml/gcc-help/2020-01/msg00106.html.
-			mask+=" -multilib"
-			force+=" multilib"
-			;;
-		*)
-			if [[ ${MULTILIB_USE} == "yes" ]] ; then
-				mask+=" -multilib"
-				force+=" multilib"
-			else
-				mask+=" multilib"
-			fi
-			;;
-	esac
+	if [[ ${MULTILIB_USE} == "yes" ]]; then
+		mask+=" -multilib"
+		force+=" multilib"
+	else
+		mask+=" multilib"
+	fi
 
 	set_use_mask ${pkg} "${mask}"
 	set_use_force ${pkg} "${force}"

--- a/scripts/container_test.sh
+++ b/scripts/container_test.sh
@@ -6,6 +6,7 @@ print_help() {
 	echo "Usage: $0 [OPTIONS]
 
 Options:
+  --env                 Specify env settings for binutils/gdb/gcc/kernel/libc. 
   --llvm                Use LLVM/Clang as a cross compiler
   --skip-system         Skip emerging the @system set after setting up crossdev.
   --tag <tag>           Specify the container tag to use. Default is 'latest'.
@@ -67,6 +68,10 @@ while [[ $# -gt 0 ]]; do
 			print_help
 			exit 0
 			;;
+		--env)
+			ENV_SETTINGS="$2"
+			shift 2
+			;;
 		--llvm)
 			USE_LLVM=1
 			shift 1
@@ -98,6 +103,9 @@ done
 EXTRA_ARGS=()
 if [[ "${USE_LLVM}" -eq 1 ]]; then
 	EXTRA_ARGS+="--llvm"
+fi
+if [[ -v ENV_SETTINGS ]]; then
+	EXTRA_ARGS+=("--env" "${ENV_SETTINGS}")
 fi
 
 "${CONTAINER_ENGINE}" run -d \


### PR DESCRIPTION
Add support for more specific arm toolchain tripples allowing for USE=-multilib in some scenarios

Bug: https://bugs.gentoo.org/976081
Closes: https://bugs.gentoo.org/868636
Signed-off-by: Alexander Barker (https://github.com/kwhat) <alex@1stleg.com>