### PR TITLE
crossdev: unmask multilib when multiple ABIs requested

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -1541,7 +1541,12 @@ set_portage() {
 			force+=" multilib"
 			;;
 		*)
-			mask+=" multilib"
+			if [[ ${MULTILIB_USE} == "yes" ]] ; then
+				mask+=" -multilib"
+				force+=" multilib"
+			else
+				mask+=" multilib"
+			fi
 			;;
 	esac
 


### PR DESCRIPTION
c439961 converted the old set_use_force/set_use_mask calls to the new mask/force pattern, but changed the *) default from removing multilib from the force list to actively masking it. These are not equivalent: the old code allowed multilib to be set via USE when multiple ABIs were requested; the new code prevented it unconditionally.

Fix by checking MULTILIB_USE and only masking when it is "no".

Fixes: c439961 ("crossdev: use package.use.{mask,force} for pie/ssp")