### PR TITLE
crossdev: fix llvm target triplet parsing

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -1929,9 +1929,9 @@ if ! ex_fast ; then
 
 		llvm_arch=""
 		case ${CTARGET} in
-			x86*) llvm_arch="X86" ;;
+			i?86*|x86*) llvm_arch="X86" ;;
+			arm64*|aarch64*) llvm_arch="AArch64" ;;
 			arm*) llvm_arch="ARM" ;;
-			aarch64*) llvm_arch="AArch64" ;;
 			riscv*) llvm_arch="RISCV" ;;
 			mips*) llvm_arch="Mips" ;;
 			loongarch*) llvm_arch="LoongArch" ;;


### PR DESCRIPTION
crossdev does not correctly handle:
- i468 and i686 -> 'target architecture not supported'
- arm64 -> checks for 'ARM' instead of 'AArch64'

map architectures to proper LLVM_TARGETS

Closes: https://bugs.gentoo.org/978823