### PR TITLE
crossdev: query compiler for supported llvm targets

### DIFF
--- a/crossdev
+++ b/crossdev
@@ -1924,9 +1924,7 @@ if ! ex_fast ; then
 		if ! ${CC} -target ${CTARGET} -mcpu=help &> /dev/null; then
 			case $? in
 				1) die "Target architecture not supported by installed LLVM toolchain" ;;
-				*) eerror "LLVM is not installed"
-				   exit 1
-				;;
+				*) die "LLVM is not installed" ;;
 			esac
 		fi
 

--- a/crossdev
+++ b/crossdev
@@ -1919,35 +1919,16 @@ if ! ex_fast ; then
 
 	# stage 0: binutils
 	if [[ "${LLVM}" == "yes" ]] ; then
-		if ! portageq has_version / "llvm-core/llvm" ; then
-			eerror "LLVM is not installed"
-			exit 1
+
+		CC=${CC:-clang}
+		if ! ${CC} -target ${CTARGET} -mcpu=help &> /dev/null; then
+			case $? in
+				1) die "Target architecture not supported by installed LLVM toolchain" ;;
+				*) eerror "LLVM is not installed"
+				   exit 1
+				;;
+			esac
 		fi
-
-		best_ver=$(portageq best_version "${EPREFIX}"/ llvm-core/llvm)
-		llvm_use=$(portageq metadata "${EPREFIX}"/ installed "${best_ver}" USE)
-
-		llvm_arch=""
-		case ${CTARGET} in
-			x86*) llvm_arch="X86" ;;
-			arm*) llvm_arch="ARM" ;;
-			aarch64*) llvm_arch="AArch64" ;;
-			riscv*) llvm_arch="RISCV" ;;
-			mips*) llvm_arch="Mips" ;;
-			loongarch*) llvm_arch="LoongArch" ;;
-			powerpc*) llvm_arch="PowerPC" ;;
-			sparc*) llvm_arch="Sparc" ;;
-		esac
-
-		supported_arch=0
-		for flag in ${llvm_use} ; do
-			if [[ ${flag} == llvm_targets_* ]] ; then
-				target=${flag#llvm_targets_}
-				[[ ${llvm_arch} == ${target} ]] && supported_arch=1
-			fi
-		done
-
-		[[ ${supported_arch} -eq 0 ]] && die "Target architecture not supported by installed LLVM toolchain"
 
 		USE="${CUSE}" doemerge ${CPKG}
 	else


### PR DESCRIPTION
for llvm targets, crossdev maps target triples to use flags to check if the toolchain supports the target. This needs updating when targets change, which may lead to bugs.

Instead query clang to get a list of supported cpus for this target, do determine the toolchain status:
- 0: ok
- 1: target not available or installed
- 127: llvm not installed

Bugs: https://bugs.gentoo.org/978823
Obsoletes: https://github.com/gentoo/crossdev/pull/46

This PR more of an enhancement than just a bug fix and a maintainer should decide if this route is desirable.